### PR TITLE
Fix Bug #213

### DIFF
--- a/templates/_composition/_shared/Page.Settings.AddInitialization_TabbedPivot/Views/wts.ItemNamePage_postaction.xaml.cs
+++ b/templates/_composition/_shared/Page.Settings.AddInitialization_TabbedPivot/Views/wts.ItemNamePage_postaction.xaml.cs
@@ -6,14 +6,7 @@ namespace Param_ItemNamespace.Views
         public wts.ItemNamePage()
         {
             InitializeComponent();
-            Loaded += OnLoaded;
-        }
-
-        //{[{
-        private void OnLoaded(object sender, RoutedEventArgs e)
-        {
             ViewModel.Initialize();
         }
-        //}]}
     }
 }


### PR DESCRIPTION
Because of the way the page was loaded inside the tab, binding was
happening before the ViewModel had been initialized so the ToggleSwitch
was first set wrong and then reset after the command was assigned. This
got the ToggleSwitch setting backwards and in turn caused the wrong
theme to be used.