### PR TITLE
Remove unneeded dependency

### DIFF
--- a/code/test/SharedFunctionality.Core.Tests/SharedFunctionality.Core.Tests.csproj
+++ b/code/test/SharedFunctionality.Core.Tests/SharedFunctionality.Core.Tests.csproj
@@ -232,7 +232,6 @@
     <PackageReference Include="NuGet.Frameworks" Version="6.1.0" />
     <PackageReference Include="NuGet.VisualStudio" Version="6.0.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
-    <PackageReference Include="System.Diagnostics.Tracing" Version="4.3.0" />
     <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
     <PackageReference Include="System.IO.Packaging" Version="6.0.0" />
     <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0" />


### PR DESCRIPTION
removing this unneeded dependency avoids issues building after a restore