### PR TITLE
Use Same project platform tags as WinnAppSDK templates

### DIFF
--- a/code/src/ProjectTemplates/WinUI/CS/Ts4WinUICsTemplate/Ts4WinUICsTemplate.vstemplate
+++ b/code/src/ProjectTemplates/WinUI/CS/Ts4WinUICsTemplate/Ts4WinUICsTemplate.vstemplate
@@ -13,6 +13,7 @@
 		<ProvideDefaultName>true</ProvideDefaultName>
 		<LanguageTag>XAML</LanguageTag>
 		<PlatformTag>Windows</PlatformTag>
+        <PlatformTag>Windows App SDK</PlatformTag>
 		<ProjectTypeTag>WinUI</ProjectTypeTag>
 		<ProjectTypeTag>desktop</ProjectTypeTag>
 	</TemplateData>


### PR DESCRIPTION
For #4418

# PR checklist

**Quick summary of changes**

Add the same platform tags as the official WinUI templates that come with the WinAppSDK

**Which issue does this PR relate to?**

For #4418

**Applies to the following platforms:**

| UWP              | WPF              | WinUI            |
| :--------------- | :--------------- | :----------------|
| No | No | Yes |

**Anything that requires particular review or attention?**

no

**Do all automated tests pass?**

yes

**Have automated tests been added for new features?**

n/a

**If you've changed the UI:**
  - Be sure you are including screenshots to show the changes.
  - Be sure you have reviewed the [accessibility checklist](accessibility.md).

na/

**If you've included a new template:**
  - Be sure you reviewed the [Template Verification Checklist](https://github.com/microsoft/WindowsTemplateStudio/wiki/Checklist:-Template-Verification).
  - Be sure it's included in the list on this [UWP](https://github.com/microsoft/WindowsTemplateStudio/blob/dev/docs/UWP/getting-started-endusers.md) or [WPF](https://github.com/microsoft/WindowsTemplateStudio/blob/dev/docs/WPF/getting-started-endusers.md) getting started doc.

n/a

**Have you raised issues for any needed follow-on work?**

n/a

**Have docs been updated?**

n/a

**If breaking changes or different ways of doing things have been introduced, have they been communicated widely?**
n/a