### PR TITLE
Don't indicate extensions as being in preview

### DIFF
--- a/code/TemplateStudioForUWP/source.extension.vsixmanifest
+++ b/code/TemplateStudioForUWP/source.extension.vsixmanifest
@@ -9,7 +9,6 @@
         <GettingStartedGuide>https://github.com/microsoft/TemplateStudio/blob/main/docs/readme.md</GettingStartedGuide>
         <Icon>TemplateStudio_Logo_90x90.png</Icon>
         <Tags>Template Studio, UWP, XAML, MVVM</Tags>
-        <Preview>true</Preview>
     </Metadata>
     <Installation>
         <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 18.0)">

--- a/code/TemplateStudioForWPF/source.extension.vsixmanifest
+++ b/code/TemplateStudioForWPF/source.extension.vsixmanifest
@@ -9,7 +9,6 @@
         <GettingStartedGuide>https://github.com/microsoft/TemplateStudio/blob/main/docs/readme.md</GettingStartedGuide>
         <Icon>TemplateStudio_Logo_90x90.png</Icon>
         <Tags>Template Studio, WPF, XAML, MVVM, Desktop</Tags>
-        <Preview>true</Preview>
     </Metadata>
     <Installation>
         <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 18.0)">

--- a/code/TemplateStudioForWinUICpp/source.extension.vsixmanifest
+++ b/code/TemplateStudioForWinUICpp/source.extension.vsixmanifest
@@ -9,7 +9,6 @@
         <GettingStartedGuide>https://github.com/microsoft/TemplateStudio/blob/main/docs/readme.md</GettingStartedGuide>
         <Icon>TemplateStudio_Logo_90x90.png</Icon>
         <Tags>Template Studio, WinUI, Desktop</Tags>
-        <Preview>true</Preview>
     </Metadata>
     <Installation>
         <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 18.0)">

--- a/code/TemplateStudioForWinUICs/source.extension.vsixmanifest
+++ b/code/TemplateStudioForWinUICs/source.extension.vsixmanifest
@@ -9,7 +9,6 @@
         <GettingStartedGuide>https://github.com/microsoft/TemplateStudio/blob/main/docs/readme.md</GettingStartedGuide>
         <Icon>TemplateStudio_Logo_90x90.png</Icon>
         <Tags>Template Studio, WinUI, XAML, MVVM, Desktop</Tags>
-        <Preview>true</Preview>
     </Metadata>
     <Installation>
         <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 18.0)">


### PR DESCRIPTION
For #4427

# PR checklist

**Quick summary of changes**

Remove the preview flag from published extensions.

**Which issue does this PR relate to?**

**Applies to the following platforms:**

| UWP              | WPF              | WinUI            |
| :--------------- | :--------------- | :----------------|
|Yes | Yes | Yes |

**Anything that requires particular review or attention?**

no

**Do all automated tests pass?**

yes

**Have automated tests been added for new features?**

n/a

**If you've changed the UI:**
  - Be sure you are including screenshots to show the changes.
  - Be sure you have reviewed the [accessibility checklist](accessibility.md).

n/a

**If you've included a new template:**
  - Be sure you reviewed the [Template Verification Checklist](https://github.com/microsoft/TemplateStudio/wiki/Checklist:-Template-Verification).
  - Be sure it's included in the list on this [UWP](https://github.com/microsoft/TemplateStudio/blob/main/docs/UWP/getting-started-endusers.md) or [WPF](https://github.com/microsoft/TemplateStudio/blob/main/docs/WPF/getting-started-endusers.md) getting started doc.

n/a

**Have you raised issues for any needed follow-on work?**

n/a

**Have docs been updated?**

n/a

**If breaking changes or different ways of doing things have been introduced, have they been communicated widely?**

n/a
