### PR TITLE
Verify UWP testing

### DIFF
--- a/code/test/TemplateStudioForUWP.Tests/TestData/UWP/SC/VBStyleAnalysis/.template.config/template.json
+++ b/code/test/TemplateStudioForUWP.Tests/TestData/UWP/SC/VBStyleAnalysis/.template.config/template.json
@@ -59,7 +59,7 @@
       "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
       "args": {
         "packageId": "VBStyleAnalyzer",
-        "version": "0.1.14",
+        "version": "0.1.12",
         "projectPath": "Param_ProjectName.Core\\Param_ProjectName.Core.vbproj"
       },
       "continueOnError": true


### PR DESCRIPTION
# PR checklist

**Quick summary of changes**

Consolidate VBStyleAnalyzer versions so that avoid a warning when running UWP VB.Net ManualOnly tests.


This change was made as part of manually verifying all  UWP tests, prior to the initial release.

Here are the test results

![image](https://user-images.githubusercontent.com/189547/165741851-75db8109-fdde-4ad0-a778-d5303b1c4326.png)

**Note.** The failing test is a "ManualOnly" test that verifies the accessibility of each generated page. **The failure is expected due to known external issues.**

Anyone wanting to recreate this test run should note the following:
- It takes a long time (1184.8 minutes is nearly 20 hours)
- Even VS2022 can't run all these tests at once without running out of memory. This means you can't just select everything, run the tests and leave it.
- Due to issues related to #4444 some of the tests report a false negative when run in parallel. Rerunning anything that fails on it's own should then lead to it passing. (This applies to Build & ManualOnly tests--the ones that take the longest already 😢 )


**Which issue does this PR relate to?**

none

**Applies to the following platforms:**

- [ ] WinUI
- [ ] WPF
- [X] UWP

**Anything that requires particular review or attention?**

n/a

**Do all automated tests pass?**

yes

**Have automated tests been added for new features?**

n/a

**If you've changed the UI:**
  - Be sure you are including screenshots to show the changes.
  - Be sure you have reviewed the [accessibility checklist](accessibility.md).

n/a

**If you've included a new template:**
  - Be sure you reviewed the [Template Verification Checklist](https://github.com/microsoft/TemplateStudio/wiki/Checklist:-Template-Verification).
  - Be sure it's included in the list on this [UWP](https://github.com/microsoft/TemplateStudio/blob/main/docs/UWP/getting-started-endusers.md) or [WPF](https://github.com/microsoft/TemplateStudio/blob/main/docs/WPF/getting-started-endusers.md) getting started doc.

n/a

**Have you raised issues for any needed follow-on work?**

n/a

**Have docs been updated?**

n/a

**If breaking changes or different ways of doing things have been introduced, have they been communicated widely?**

n/a
