### PR TITLE
Moved MSIX to Deployment group and removed redundant "Deployment" from Self-Contained.

### DIFF
--- a/code/TemplateStudioForWinUICs/Templates/Ft/MSIX/.template.config/template.json
+++ b/code/TemplateStudioForWinUICs/Templates/Ft/MSIX/.template.config/template.json
@@ -19,7 +19,7 @@
     "ts.appmodel": "Desktop",
     "ts.version": "1.0.0",
     "ts.genGroup": "0",
-    "ts.group": "Packaging",
+    "ts.group": "Deployment",
     "ts.displayOrder": "1",
     "ts.defaultInstance": "MSIX Packaging",
     "ts.multipleInstance": "false",

--- a/code/TemplateStudioForWinUICs/Templates/Ft/SelfContained/.template.config/template.json
+++ b/code/TemplateStudioForWinUICs/Templates/Ft/SelfContained/.template.config/template.json
@@ -4,8 +4,8 @@
     "classifications": [
         "Universal"
     ],
-    "name": "Self-Contained Deployment",
-    "shortName": "Self-Contained Deployment",
+    "name": "Self-Contained",
+    "shortName": "Self-Contained",
     "groupIdentity": "ts.WinUI.Feat.SelfContained",
     "identity": "ts.WinUI.Feat.SelfContained",
     "description": "Ship Windows App SDK dependencies as part of your application.",


### PR DESCRIPTION
# PR checklist

**Quick summary of changes**
Moved MSIX to Deployment to be next to Self-Contained and better utilize horizontal space. Renamed "Self-Contained Deployment" to just "Self-Contained" since Deployment is already covered by the group header.

**Which issue does this PR relate to?**

**Applies to the following platforms:**

- [X] WinUI
- [ ] WPF
- [ ] UWP

**Anything that requires particular review or attention?**

**Do all automated tests pass?**

**Have automated tests been added for new features?**

**If you've changed the UI:**
  - Be sure you are including screenshots to show the changes.
  - Be sure you have reviewed the [accessibility checklist](accessibility.md).

**If you've included a new template:**
  - Be sure you reviewed the [Template Verification Checklist](https://github.com/microsoft/TemplateStudio/wiki/Checklist:-Template-Verification).
  - Be sure it's included in the list on this [UWP](https://github.com/microsoft/TemplateStudio/blob/main/docs/UWP/getting-started-endusers.md) or [WPF](https://github.com/microsoft/TemplateStudio/blob/main/docs/WPF/getting-started-endusers.md) getting started doc.

**Have you raised issues for any needed follow-on work?**

**Have docs been updated?**

**If breaking changes or different ways of doing things have been introduced, have they been communicated widely?**
