### PR TITLE
Make NavigationView the default selected project.

### DIFF
--- a/code/TemplateStudioForWinUICs/Templates/_catalog/projectTypes.json
+++ b/code/TemplateStudioForWinUICs/Templates/_catalog/projectTypes.json
@@ -1,19 +1,10 @@
 ﻿[
     {
-      "name": "Blank",
-      "displayName": "Blank",
-      "summary": "A navigation frame and basic services and styles are included.",
-      "author": "Microsoft",
-      "order": "1",
-      "platform": "WinUI",
-      "languages": [ "C#" ]
-    },
-    {
       "name": "SplitView",
       "displayName": "Navigation Pane",
       "summary": "A navigation pane (or 'hamburger menu') is included for navigation between pages.",
       "author": "Microsoft",
-      "order": "2",
+      "order": "1",
       "platform": "WinUI",
       "languages": [ "C#" ]
     },
@@ -21,6 +12,15 @@
       "name": "MenuBar",
       "displayName": "MenuBar",
       "summary": "A menu is added to move around between pages.",
+      "author": "Microsoft",
+      "order": "2",
+      "platform": "WinUI",
+      "languages": [ "C#" ]
+    },
+    {
+      "name": "Blank",
+      "displayName": "Blank",
+      "summary": "A navigation frame and basic services and styles are included.",
       "author": "Microsoft",
       "order": "3",
       "platform": "WinUI",

--- a/code/test/SharedFunctionality.UI.Tests/ProjectTests/NewWinUICsProjectTest.cs
+++ b/code/test/SharedFunctionality.UI.Tests/ProjectTests/NewWinUICsProjectTest.cs
@@ -16,7 +16,7 @@ namespace Microsoft.UI.Test.ProjectTests
     [Trait("Group", "Minimum")]
     public class NewWinUICsProjectTest : IClassFixture<WinUICsPlatformTemplatesFixture>
     {
-        private const string DefaultProjectType = "Blank";
+        private const string DefaultProjectType = "SplitView";
         private const string DefaultFramework = "MVVMToolkit";
 
         public NewWinUICsProjectTest(WinUICsPlatformTemplatesFixture fixture)


### PR DESCRIPTION
# PR checklist

**Quick summary of changes**
Updated projecttypes.json to reorder the project types. NavigationView is first so it is selected by default, followed by MenuBar, then Blank. This ordering follows the expected usage patterns as well.

**Which issue does this PR relate to?**
#4499 

**Applies to the following platforms:**

- [x] WinUI
- [ ] WPF
- [ ] UWP

**Anything that requires particular review or attention?**

**Do all automated tests pass?**

**Have automated tests been added for new features?**

**If you've changed the UI:**
  - Be sure you are including screenshots to show the changes.
  - Be sure you have reviewed the [accessibility checklist](accessibility.md).

**If you've included a new template:**
  - Be sure you reviewed the [Template Verification Checklist](https://github.com/microsoft/TemplateStudio/wiki/Checklist:-Template-Verification).
  - Be sure it's included in the list on this [UWP](https://github.com/microsoft/TemplateStudio/blob/main/docs/UWP/getting-started-endusers.md) or [WPF](https://github.com/microsoft/TemplateStudio/blob/main/docs/WPF/getting-started-endusers.md) getting started doc.

**Have you raised issues for any needed follow-on work?**

**Have docs been updated?**

**If breaking changes or different ways of doing things have been introduced, have they been communicated widely?**
