### PR TITLE
Remove custom styles to honor default control behaviors and designer feedback

### DIFF
--- a/code/TemplateStudioForWinUICs/TemplateStudioForWinUICs.csproj
+++ b/code/TemplateStudioForWinUICs/TemplateStudioForWinUICs.csproj
@@ -390,10 +390,6 @@
     <Content Include="Templates\Ft\MSIX\Assets\Wide310x150Logo.scale-200.png">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="Templates\_comp\_shared\Page.AddTitle.Blank\Views\Param_ItemNamePage_postaction.xaml">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-    </Content>
     <Content Include="tr-TR\Extension.vsixlangpack">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
@@ -2144,6 +2140,9 @@
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="Templates\_comp\MT\Project.SplitView\Views\ShellPage.xaml">
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+    <Content Include="Templates\_comp\_shared\Page.AddTitle.Blank\Views\Param_ItemNamePage_postaction.xaml">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="Templates\_comp\_shared\Page.AddTitle.ContentGrid\Views\Param_ItemNamePage_postaction.xaml">

--- a/code/TemplateStudioForWinUICs/TemplateStudioForWinUICs.csproj
+++ b/code/TemplateStudioForWinUICs/TemplateStudioForWinUICs.csproj
@@ -390,6 +390,10 @@
     <Content Include="Templates\Ft\MSIX\Assets\Wide310x150Logo.scale-200.png">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <Content Include="Templates\_comp\_shared\Page.AddTitle.Blank\Views\Param_ItemNamePage_postaction.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Content>
     <Content Include="tr-TR\Extension.vsixlangpack">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
@@ -2140,9 +2144,6 @@
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="Templates\_comp\MT\Project.SplitView\Views\ShellPage.xaml">
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
-    <Content Include="Templates\_comp\_shared\Page.AddTitle.Blank\Views\Param_ItemNamePage_postaction.xaml">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="Templates\_comp\_shared\Page.AddTitle.ContentGrid\Views\Param_ItemNamePage_postaction.xaml">

--- a/code/TemplateStudioForWinUICs/Templates/Pg/Blank/Views/Param_ItemNamePage.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/Pg/Blank/Views/Param_ItemNamePage.xaml
@@ -4,16 +4,9 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
-    Style="{StaticResource PageStyle}">
+    mc:Ignorable="d">
 
-    <Grid x:Name="ContentArea" Margin="{StaticResource MediumLeftRightMargin}">
-        <Grid
-            Background="{ThemeResource SystemControlPageBackgroundChromeLowBrush}">
-            <!--
-                The SystemControlPageBackgroundChromeLowBrush background represents where you should place your content.
-                Place your content here.
-            -->
-        </Grid>
+    <Grid x:Name="ContentArea">
+        
     </Grid>
 </Page>

--- a/code/TemplateStudioForWinUICs/Templates/Pg/CGrid/Param_ProjectName/Views/Param_ItemNameDetailPage.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/Pg/CGrid/Param_ProjectName/Views/Param_ItemNameDetailPage.xaml
@@ -8,8 +8,7 @@
     xmlns:models="using:Param_RootNamespace.Core.Models"
     mc:Ignorable="d">
 
-    <Grid
-        x:Name="ContentArea">
+    <Grid x:Name="ContentArea">
 
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup>

--- a/code/TemplateStudioForWinUICs/Templates/Pg/CGrid/Param_ProjectName/Views/Param_ItemNameDetailPage.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/Pg/CGrid/Param_ProjectName/Views/Param_ItemNameDetailPage.xaml
@@ -6,8 +6,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:CommunityToolkit.WinUI.UI.Controls"
     xmlns:models="using:Param_RootNamespace.Core.Models"
-    mc:Ignorable="d"
-    Style="{StaticResource PageStyle}">
+    mc:Ignorable="d">
 
     <Grid
         x:Name="ContentArea">
@@ -33,7 +32,6 @@
         <ScrollViewer
             IsTabStop="True">
             <StackPanel
-                Margin="{StaticResource MediumLeftRightMargin}"
                 x:Name="contentPanel">
                 <RelativePanel>
                     <Grid
@@ -44,7 +42,6 @@
                         Padding="{StaticResource XSmallLeftTopRightBottomMargin}"
                         HorizontalAlignment="Left"
                         VerticalAlignment="Top"
-                        Background="{ThemeResource SystemControlPageBackgroundChromeLowBrush}"
                         RelativePanel.AlignTopWithPanel="True"
                         RelativePanel.AlignLeftWithPanel="True">
                         <FontIcon

--- a/code/TemplateStudioForWinUICs/Templates/Pg/CGrid/Param_ProjectName/Views/Param_ItemNamePage.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/Pg/CGrid/Param_ProjectName/Views/Param_ItemNamePage.xaml
@@ -7,12 +7,10 @@
     xmlns:animations="using:CommunityToolkit.WinUI.UI.Animations"
     xmlns:controls="using:CommunityToolkit.WinUI.UI.Controls"
     xmlns:models="using:Param_RootNamespace.Core.Models"
-    mc:Ignorable="d"
-    Style="{StaticResource PageStyle}">
+    mc:Ignorable="d">
 
     <Grid x:Name="ContentArea">
         <controls:AdaptiveGridView
-            Padding="{StaticResource MediumLeftRightMargin}"
             animations:Connected.ListItemElementName="itemThumbnail"
             animations:Connected.ListItemKey="animationKeyContentGrid"
             DesiredWidth="180"
@@ -26,8 +24,7 @@
                 <DataTemplate x:DataType="models:SampleOrder">
                     <Grid
                         x:Name="itemThumbnail"
-                        Padding="{StaticResource XSmallLeftTopRightBottomMargin}"
-                        Background="{ThemeResource SystemControlPageBackgroundChromeLowBrush}">
+                        Padding="{StaticResource XSmallLeftTopRightBottomMargin}">
                         <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
                             <FontIcon
                                 Glyph="{x:Bind Symbol}"

--- a/code/TemplateStudioForWinUICs/Templates/Pg/DGrid/Param_ProjectName/Views/Param_ItemNamePage.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/Pg/DGrid/Param_ProjectName/Views/Param_ItemNamePage.xaml
@@ -24,7 +24,6 @@
                     <controls:DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
                             <FontIcon
-                                    Margin="{StaticResource SmallLeftRightMargin}"
                                     HorizontalAlignment="Left"
                                     FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                     Glyph="{Binding Symbol}"

--- a/code/TemplateStudioForWinUICs/Templates/Pg/DGrid/Param_ProjectName/Views/Param_ItemNamePage.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/Pg/DGrid/Param_ProjectName/Views/Param_ItemNamePage.xaml
@@ -5,10 +5,9 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:CommunityToolkit.WinUI.UI.Controls"
-    mc:Ignorable="d"
-    Style="{StaticResource PageStyle}">
+    mc:Ignorable="d">
 
-    <Grid x:Name="ContentArea" Margin="{StaticResource MediumLeftRightMargin}">
+    <Grid x:Name="ContentArea">
         <controls:DataGrid
             AutoGenerateColumns="False"
             GridLinesVisibility="Horizontal"

--- a/code/TemplateStudioForWinUICs/Templates/Pg/List/Param_ProjectName/Views/Param_ItemNameDetailControl.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/Pg/List/Param_ProjectName/Views/Param_ItemNameDetailControl.xaml
@@ -9,8 +9,6 @@
         Name="ForegroundElement"
         HorizontalAlignment="Stretch"
         VerticalScrollMode="Enabled"
-        Padding="{StaticResource DetailPageMargin}"
-        Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
         IsTabStop="True">
         <StackPanel HorizontalAlignment="Left">
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch">

--- a/code/TemplateStudioForWinUICs/Templates/Pg/List/Param_ProjectName/Views/Param_ItemNamePage.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/Pg/List/Param_ProjectName/Views/Param_ItemNamePage.xaml
@@ -7,8 +7,7 @@
     xmlns:controls="using:CommunityToolkit.WinUI.UI.Controls"
     xmlns:models="using:Param_RootNamespace.Core.Models"
     xmlns:views="using:Param_RootNamespace.Views"
-    mc:Ignorable="d"
-    Style="{StaticResource PageStyle}">
+    mc:Ignorable="d">
     <Page.Resources>
         <DataTemplate x:Key="ItemTemplate" x:DataType="models:SampleOrder">
             <Grid Height="60">
@@ -33,13 +32,13 @@
         </DataTemplate>
 
         <DataTemplate x:Key="DetailsTemplate">
-            <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+            <Grid>
                 <views:Param_ItemNameDetailControl ListDetailsMenuItem="{Binding}" />
             </Grid>
         </DataTemplate>
 
         <DataTemplate x:Key="NoSelectionContentTemplate">
-            <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+            <Grid>
                 <TextBlock
                     x:Uid="Param_ItemName_NoSelection"
                     HorizontalAlignment="Center"
@@ -70,7 +69,6 @@
             ListHeaderTemplate="{StaticResource ListHeaderTemplate}"
             NoSelectionContentTemplate="{StaticResource NoSelectionContentTemplate}"
             SelectedItem="{x:Bind ViewModel.Selected, Mode=TwoWay}"
-            ViewStateChanged="OnViewStateChanged"
-            Background="{ThemeResource SystemControlPageBackgroundChromeLowBrush}" />
+            ViewStateChanged="OnViewStateChanged"/>
     </Grid>
 </Page>

--- a/code/TemplateStudioForWinUICs/Templates/Pg/Settings/Views/Param_ItemNamePage.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/Pg/Settings/Views/Param_ItemNamePage.xaml
@@ -60,7 +60,7 @@
                     x:Uid="Settings_AboutDescription"
                     Margin="{StaticResource XSmallTopMargin}"
                     Style="{ThemeResource BodyTextBlockStyle}" />
-                <HyperlinkButton x:Uid="SettingsPage_PrivacyTermsLink" Margin="{StaticResource SettingsHyperLink}" />
+                <HyperlinkButton x:Uid="SettingsPage_PrivacyTermsLink" Margin="{StaticResource SettingsPageHyperlinkButtonMargin}" />
             </StackPanel>
         </StackPanel>
     </Grid>

--- a/code/TemplateStudioForWinUICs/Templates/Pg/Settings/Views/Param_ItemNamePage.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/Pg/Settings/Views/Param_ItemNamePage.xaml
@@ -6,12 +6,11 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:helpers="using:Param_RootNamespace.Helpers"
     xmlns:xaml="using:Microsoft.UI.Xaml"
-    mc:Ignorable="d"
-    Style="{StaticResource PageStyle}">
+    mc:Ignorable="d">
     <Page.Resources>
         <helpers:EnumToBooleanConverter x:Key="EnumToBooleanConverter" />
     </Page.Resources>
-    <Grid Margin="{StaticResource MediumLeftRightMargin}">
+    <Grid>
         <StackPanel
             x:Name="ContentArea">
             <TextBlock x:Uid="Settings_Personalization" Style="{ThemeResource SubtitleTextBlockStyle}" />
@@ -61,7 +60,7 @@
                     x:Uid="Settings_AboutDescription"
                     Margin="{StaticResource XSmallTopMargin}"
                     Style="{ThemeResource BodyTextBlockStyle}" />
-                <HyperlinkButton x:Uid="SettingsPage_PrivacyTermsLink" Margin="{StaticResource XSmallTopMargin}" />
+                <HyperlinkButton x:Uid="SettingsPage_PrivacyTermsLink" Margin="{StaticResource SettingsHyperLink}" />
             </StackPanel>
         </StackPanel>
     </Grid>

--- a/code/TemplateStudioForWinUICs/Templates/Pg/WebView/Views/Param_ItemNamePage.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/Pg/WebView/Views/Param_ItemNamePage.xaml
@@ -4,8 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
-    Style="{StaticResource PageStyle}">
+    mc:Ignorable="d">
 
     <Grid x:Name="ContentArea">
         <Grid.RowDefinitions>
@@ -33,7 +32,7 @@
             <HyperlinkButton x:Uid="WebView_Reload" Command="{x:Bind ViewModel.ReloadCommand}" HorizontalAlignment="Center" />
         </StackPanel>
 
-        <Grid Grid.Row="1" Background="{ThemeResource SystemControlChromeHighAcrylicElementMediumBrush}">
+        <Grid Grid.Row="1">
             <StackPanel Orientation="Horizontal">
                 <Button x:Uid="BrowserBackButton" Command="{x:Bind ViewModel.BrowserBackCommand, Mode=OneWay}" Margin="{StaticResource XSmallLeftTopRightBottomMargin}" Padding="{StaticResource XXSmallLeftTopRightBottomMargin}">
                     <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE72B;" />

--- a/code/TemplateStudioForWinUICs/Templates/Proj/Default/Param_ProjectName/Styles/Thickness.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/Proj/Default/Param_ProjectName/Styles/Thickness.xaml
@@ -25,7 +25,7 @@
 
     <Thickness x:Key="DetailPageMargin">52,40,52,0</Thickness>
     <Thickness x:Key="SettingsHyperLink">-12, 4, 0, 0</Thickness>
-    <Thickness x:Key="NavigationViewContentMargin">68, 24, 0, 0</Thickness>
+    <Thickness x:Key="NavigationViewContentMargin">55, 24, 0, 0</Thickness>
     <Thickness x:Key="MenuBarContentMargin">36, 24, 0, 0</Thickness>
 
 </ResourceDictionary>

--- a/code/TemplateStudioForWinUICs/Templates/Proj/Default/Param_ProjectName/Styles/Thickness.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/Proj/Default/Param_ProjectName/Styles/Thickness.xaml
@@ -22,11 +22,10 @@
 
     <Thickness x:Key="XXSmallTopMargin">0, 4, 0, 0</Thickness>
     <Thickness x:Key="XXSmallLeftTopRightBottomMargin">4, 4, 4, 4</Thickness>
-
-    <Thickness x:Key="DetailPageMargin">52,40,52,0</Thickness>
-    <Thickness x:Key="SettingsPageHyperlinkButtonMargin">-12, 4, 0, 0</Thickness>
     
     <Thickness x:Key="NavigationViewContentMargin">55, 24, 0, 0</Thickness>
     <Thickness x:Key="MenuBarContentMargin">36, 24, 0, 0</Thickness>
 
+    <Thickness x:Key="SettingsPageHyperlinkButtonMargin">-12, 4, 0, 0</Thickness>
+    
 </ResourceDictionary>

--- a/code/TemplateStudioForWinUICs/Templates/Proj/Default/Param_ProjectName/Styles/Thickness.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/Proj/Default/Param_ProjectName/Styles/Thickness.xaml
@@ -26,5 +26,6 @@
     <Thickness x:Key="DetailPageMargin">52,40,52,0</Thickness>
     <Thickness x:Key="SettingsHyperLink">-12, 4, 0, 0</Thickness>
     <Thickness x:Key="NavigationViewContentMargin">68, 24, 0, 0</Thickness>
+    <Thickness x:Key="MenuBarContentMargin">36, 24, 0, 0</Thickness>
 
 </ResourceDictionary>

--- a/code/TemplateStudioForWinUICs/Templates/Proj/Default/Param_ProjectName/Styles/Thickness.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/Proj/Default/Param_ProjectName/Styles/Thickness.xaml
@@ -24,7 +24,8 @@
     <Thickness x:Key="XXSmallLeftTopRightBottomMargin">4, 4, 4, 4</Thickness>
 
     <Thickness x:Key="DetailPageMargin">52,40,52,0</Thickness>
-    <Thickness x:Key="SettingsHyperLink">-12, 4, 0, 0</Thickness>
+    <Thickness x:Key="SettingsPageHyperlinkButtonMargin">-12, 4, 0, 0</Thickness>
+    
     <Thickness x:Key="NavigationViewContentMargin">55, 24, 0, 0</Thickness>
     <Thickness x:Key="MenuBarContentMargin">36, 24, 0, 0</Thickness>
 

--- a/code/TemplateStudioForWinUICs/Templates/Proj/Default/Param_ProjectName/Styles/Thickness.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/Proj/Default/Param_ProjectName/Styles/Thickness.xaml
@@ -24,5 +24,7 @@
     <Thickness x:Key="XXSmallLeftTopRightBottomMargin">4, 4, 4, 4</Thickness>
 
     <Thickness x:Key="DetailPageMargin">52,40,52,0</Thickness>
+    <Thickness x:Key="SettingsHyperLink">-12, 4, 0, 0</Thickness>
+    <Thickness x:Key="NavigationViewContentMargin">68, 24, 0, 0</Thickness>
 
 </ResourceDictionary>

--- a/code/TemplateStudioForWinUICs/Templates/_comp/MT/Page.AddBackCommand/Views/Param_ItemNameDetailPage_postaction.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/_comp/MT/Page.AddBackCommand/Views/Param_ItemNameDetailPage_postaction.xaml
@@ -1,8 +1,7 @@
 ﻿<Page
-    Style="{StaticResource PageStyle}">
+    mc:Ignorable="d">
 
-    <Grid
-        x:Name="ContentArea">
+    <Grid x:Name="ContentArea">
 <!--{[{-->
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto" />

--- a/code/TemplateStudioForWinUICs/Templates/_comp/MT/Project.MenuBar/Views/ShellPage.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/_comp/MT/Project.MenuBar/Views/ShellPage.xaml
@@ -16,7 +16,7 @@
                 x:Name="rightFrame"
                 BorderThickness="1,1,0,0"
                 BorderBrush="Gray"
-                Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"/>
+                Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" />
         </SplitView.Pane>
         <Grid>
             <Grid.RowDefinitions>

--- a/code/TemplateStudioForWinUICs/Templates/_comp/MT/Project.MenuBar/Views/ShellPage.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/_comp/MT/Project.MenuBar/Views/ShellPage.xaml
@@ -6,8 +6,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     Loaded="OnLoaded"
     Unloaded="OnUnloaded"
-    mc:Ignorable="d"
-    Style="{StaticResource PageStyle}">
+    mc:Ignorable="d">
     <SplitView
         x:Name="splitView"
         PanePlacement="Right"
@@ -17,7 +16,7 @@
                 x:Name="rightFrame"
                 BorderThickness="1,1,0,0"
                 BorderBrush="Gray"
-                Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" />
+                Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"/>
         </SplitView.Pane>
         <Grid>
             <Grid.RowDefinitions>
@@ -42,7 +41,7 @@
                     </MenuBarItem>
                 </MenuBar.Items>
             </MenuBar>
-            <Grid Grid.Row="1">
+            <Grid Grid.Row="1" Margin="{StaticResource MenuBarContentMargin}">
                 <Frame x:Name="shellFrame" />
             </Grid>
         </Grid>

--- a/code/TemplateStudioForWinUICs/Templates/_comp/MT/Project.SplitView/Views/ShellPage.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/_comp/MT/Project.SplitView/Views/ShellPage.xaml
@@ -7,8 +7,7 @@
     xmlns:helpers="using:Param_RootNamespace.Helpers"
     xmlns:behaviors="using:Param_RootNamespace.Behaviors"
     xmlns:i="using:Microsoft.Xaml.Interactivity"
-    Loaded="OnLoaded"
-    Style="{StaticResource PageStyle}">
+    Loaded="OnLoaded">
 
     <NavigationView
         x:Name="navigationView"
@@ -53,8 +52,8 @@
                 </behaviors:NavigationViewHeaderBehavior.DefaultHeaderTemplate>
             </behaviors:NavigationViewHeaderBehavior>
         </i:Interaction.Behaviors>
-        <Grid>
-            <Frame x:Name="shellFrame" />
+        <Grid Margin="{StaticResource NavigationViewContentMargin}">
+            <Frame x:Name="shellFrame"/>
         </Grid>
     </NavigationView>
 </Page>

--- a/code/TemplateStudioForWinUICs/Templates/_comp/MT/Project.SplitView/Views/ShellPage.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/_comp/MT/Project.SplitView/Views/ShellPage.xaml
@@ -32,8 +32,7 @@
                 <Grid>
                     <TextBlock
                         Text="{Binding}"
-                        Style="{ThemeResource TitleTextBlockStyle}"
-                        Margin="{StaticResource SmallLeftRightMargin}" />
+                        Style="{ThemeResource TitleTextBlockStyle}" />
                 </Grid>
             </DataTemplate>
         </NavigationView.HeaderTemplate>
@@ -45,8 +44,7 @@
                         <Grid>
                             <TextBlock
                                 Text="{Binding}"
-                                Style="{ThemeResource TitleTextBlockStyle}"
-                                Margin="{StaticResource SmallLeftRightMargin}" />
+                                Style="{ThemeResource TitleTextBlockStyle}" />
                         </Grid>
                     </DataTemplate>
                 </behaviors:NavigationViewHeaderBehavior.DefaultHeaderTemplate>

--- a/code/TemplateStudioForWinUICs/Templates/_comp/_shared/Page.AddTitle.Blank/Views/Param_ItemNamePage_postaction.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/_comp/_shared/Page.AddTitle.Blank/Views/Param_ItemNamePage_postaction.xaml
@@ -1,6 +1,6 @@
 ﻿<Page
     mc:Ignorable="d">
-    
+
     <Grid x:Name="ContentArea">
 <!--{[{-->
         <Grid.RowDefinitions>

--- a/code/TemplateStudioForWinUICs/Templates/_comp/_shared/Page.AddTitle.Blank/Views/Param_ItemNamePage_postaction.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/_comp/_shared/Page.AddTitle.Blank/Views/Param_ItemNamePage_postaction.xaml
@@ -1,12 +1,20 @@
 ﻿<Page
-    x:Class="Param_RootNamespace.Views.Param_ItemNamePage"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
-
+    
     <Grid x:Name="ContentArea">
+<!--{[{-->
+        <Grid.RowDefinitions>
+            <RowDefinition Height="48" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
 
-    </Grid>
+        <TextBlock
+            Grid.Row="0"
+            x:Uid="Param_ItemName_Title"
+            Style="{StaticResource PageTitleStyle}" />
+
+        <Grid Grid.Row="1">
+            
+        </Grid>
+<!--}]}-->
 </Page>

--- a/code/TemplateStudioForWinUICs/Templates/_comp/_shared/Page.AddTitle.Blank/Views/Param_ItemNamePage_postaction.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/_comp/_shared/Page.AddTitle.Blank/Views/Param_ItemNamePage_postaction.xaml
@@ -1,22 +1,12 @@
 ﻿<Page
-    Style="{StaticResource PageStyle}">
-    <Grid x:Name="ContentArea" Margin="{StaticResource MediumLeftRightMargin}">
-<!--{[{-->
-        <Grid.RowDefinitions>
-            <RowDefinition Height="48" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
+    x:Class="Param_RootNamespace.Views.Param_ItemNamePage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
 
-        <TextBlock
-            Grid.Row="0"
-            x:Uid="Param_ItemName_Title"
-            Style="{StaticResource PageTitleStyle}" />
-<!--}]}-->
-        <Grid
-<!--{[{-->
-            Grid.Row="1" 
-<!--}]}-->
-            Background="{ThemeResource SystemControlPageBackgroundChromeLowBrush}">
-        </Grid>
+    <Grid x:Name="ContentArea">
+
     </Grid>
 </Page>

--- a/code/TemplateStudioForWinUICs/Templates/_comp/_shared/Page.AddTitle.ContentGrid/Views/Param_ItemNamePage_postaction.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/_comp/_shared/Page.AddTitle.ContentGrid/Views/Param_ItemNamePage_postaction.xaml
@@ -11,7 +11,6 @@
         <TextBlock
             Grid.Row="0"
             x:Uid="Param_ItemName_Title"
-            Margin="{StaticResource MediumLeftRightMargin}"
             Style="{StaticResource PageTitleStyle}" />
 <!--}]}-->
         <controls:AdaptiveGridView

--- a/code/TemplateStudioForWinUICs/Templates/_comp/_shared/Page.AddTitle.ContentGrid/Views/Param_ItemNamePage_postaction.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/_comp/_shared/Page.AddTitle.ContentGrid/Views/Param_ItemNamePage_postaction.xaml
@@ -1,5 +1,6 @@
 ﻿<Page
-    Style="{StaticResource PageStyle}">
+    mc:Ignorable="d">
+
     <Grid x:Name="ContentArea">
 <!--{[{-->
         <Grid.RowDefinitions>

--- a/code/TemplateStudioForWinUICs/Templates/_comp/_shared/Page.AddTitle.DataGrid/Views/Param_ItemNamePage_postaction.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/_comp/_shared/Page.AddTitle.DataGrid/Views/Param_ItemNamePage_postaction.xaml
@@ -1,6 +1,7 @@
 ﻿<Page
-    Style="{StaticResource PageStyle}">
-    <Grid x:Name="ContentArea" Margin="{StaticResource MediumLeftRightMargin}">
+    mc:Ignorable="d">
+
+    <Grid x:Name="ContentArea">
 <!--{[{-->
         <Grid.RowDefinitions>
             <RowDefinition Height="48" />

--- a/code/TemplateStudioForWinUICs/Templates/_comp/_shared/Page.AddTitle.Settings/Views/Param_ItemNamePage_postaction.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/_comp/_shared/Page.AddTitle.Settings/Views/Param_ItemNamePage_postaction.xaml
@@ -1,6 +1,6 @@
 ﻿<Page
-    Style="{StaticResource PageStyle}">
-    <Grid Margin="{StaticResource MediumLeftRightMargin}">
+    mc:Ignorable="d">
+    <Grid>
 <!--{[{-->
         <Grid.RowDefinitions>
             <RowDefinition Height="48" />

--- a/code/TemplateStudioForWinUICs/Templates/_comp/_shared/Page.ListDetail.Blank.MenuBar/Views/Param_ItemNamePage_postaction.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/_comp/_shared/Page.ListDetail.Blank.MenuBar/Views/Param_ItemNamePage_postaction.xaml
@@ -1,5 +1,5 @@
 ﻿<Page
-    Style="{StaticResource PageStyle}">
+    mc:Ignorable="d">
 
     <Grid x:Name="ContentArea">
         <controls:ListDetailsView
@@ -8,6 +8,6 @@
 <!--{[{-->
             BackButtonBehavior="Inline"
 <!--}]}-->
-            Background="{ThemeResource SystemControlPageBackgroundChromeLowBrush}" />
+            ViewStateChanged="OnViewStateChanged"/>
     </Grid>
 </Page>

--- a/code/TemplateStudioForWinUICs/Templates/_comp/_shared/Page.ListDetail.SplitView/Views/Param_ItemNamePage_postaction.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/_comp/_shared/Page.ListDetail.SplitView/Views/Param_ItemNamePage_postaction.xaml
@@ -4,7 +4,7 @@
     xmlns:behaviors="using:Param_RootNamespace.Behaviors"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     <!--}]}-->
-    Style="{StaticResource PageStyle}">
+    mc:Ignorable="d">
 
     <Page.Resources>
         <!--^^-->
@@ -50,6 +50,6 @@
             <!--{[{-->
             ListHeaderTemplate="{StaticResource MinimalListHeaderTemplate}"
             <!--}]}-->
-            Background="{ThemeResource SystemControlPageBackgroundChromeLowBrush}" />
+            NoSelectionContentTemplate="{StaticResource NoSelectionContentTemplate}"
     </Grid>
 </Page>

--- a/code/TemplateStudioForWinUICs/Templates/_comp/_shared/Page.SplitView.AddHeaderModeMinimal/Views/Param_ItemNamePage_postaction.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/_comp/_shared/Page.SplitView.AddHeaderModeMinimal/Views/Param_ItemNamePage_postaction.xaml
@@ -4,5 +4,5 @@
     xmlns:behaviors="using:Param_RootNamespace.Behaviors"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Minimal"
     <!--}]}-->
-    Style="{StaticResource PageStyle}">
+    mc:Ignorable="d">
 </Page>

--- a/code/TemplateStudioForWinUICs/Templates/_comp/_shared/Page.SplitView.AddHeaderModeNever/Views/Param_ItemNamePage_postaction.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/_comp/_shared/Page.SplitView.AddHeaderModeNever/Views/Param_ItemNamePage_postaction.xaml
@@ -4,5 +4,5 @@
     xmlns:behaviors="using:Param_RootNamespace.Behaviors"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
     <!--}]}-->
-    Style="{StaticResource PageStyle}">
+    mc:Ignorable="d">
 </Page>


### PR DESCRIPTION
 Removed unnecessary Page, Frame, and Grid Styles and BackgroundColors

Issue: #4463 

**Applies to the following platforms:**

- [x] WinUI
- [ ] WPF
- [ ] UWP

- ListDetail Control looks like it has some built-in styling
![s](https://user-images.githubusercontent.com/66053234/169417908-08a9a95f-21e0-48c0-bddf-9d59540367d0.png)
- Styling on ShellPage.xaml (SystemControlBackgroudAltHighBrush) needs to be included for theming (light/dark) to work
- It is possible that an issue with the maximize, minimize, and close buttons (on custom titlebar) blending in on light theme is fixed with the removal of styling