### PR TITLE
Don't use GUID also used elsewhere

### DIFF
--- a/code/src/ProjectTemplates/UWP/CS/Ts4UwpCsTemplate/Ts4UwpCsTemplate.cs-CZ.vstemplate
+++ b/code/src/ProjectTemplates/UWP/CS/Ts4UwpCsTemplate/Ts4UwpCsTemplate.cs-CZ.vstemplate
@@ -9,7 +9,7 @@
 		<ProjectType>CSharp</ProjectType>
 		<LanguageTag>csharp</LanguageTag>
 		<SortOrder>10</SortOrder>
-		<TemplateID>61f19320-3820-4efd-a3e8-e1b1cca3352f</TemplateID>
+        <TemplateID>4EB69C1D-F03A-4842-9466-7A33EBB84528</TemplateID>
 		<CreateNewFolder>true</CreateNewFolder>
 		<DefaultName>App</DefaultName>
 		<ProvideDefaultName>true</ProvideDefaultName>

--- a/code/src/ProjectTemplates/UWP/CS/Ts4UwpCsTemplate/Ts4UwpCsTemplate.de-DE.vstemplate
+++ b/code/src/ProjectTemplates/UWP/CS/Ts4UwpCsTemplate/Ts4UwpCsTemplate.de-DE.vstemplate
@@ -9,7 +9,7 @@
 		<ProjectType>CSharp</ProjectType>
 		<LanguageTag>csharp</LanguageTag>
 		<SortOrder>10</SortOrder>
-		<TemplateID>61f19320-3820-4efd-a3e8-e1b1cca3352f</TemplateID>
+        <TemplateID>4EB69C1D-F03A-4842-9466-7A33EBB84528</TemplateID>
 		<CreateNewFolder>true</CreateNewFolder>
 		<DefaultName>App</DefaultName>
 		<ProvideDefaultName>true</ProvideDefaultName>

--- a/code/src/ProjectTemplates/UWP/CS/Ts4UwpCsTemplate/Ts4UwpCsTemplate.es-ES.vstemplate
+++ b/code/src/ProjectTemplates/UWP/CS/Ts4UwpCsTemplate/Ts4UwpCsTemplate.es-ES.vstemplate
@@ -9,7 +9,7 @@
 		<ProjectType>CSharp</ProjectType>
 		<LanguageTag>csharp</LanguageTag>
 		<SortOrder>10</SortOrder>
-		<TemplateID>61f19320-3820-4efd-a3e8-e1b1cca3352f</TemplateID>
+        <TemplateID>4EB69C1D-F03A-4842-9466-7A33EBB84528</TemplateID>
 		<CreateNewFolder>true</CreateNewFolder>
 		<DefaultName>App</DefaultName>
 		<ProvideDefaultName>true</ProvideDefaultName>

--- a/code/src/ProjectTemplates/UWP/CS/Ts4UwpCsTemplate/Ts4UwpCsTemplate.fr-FR.vstemplate
+++ b/code/src/ProjectTemplates/UWP/CS/Ts4UwpCsTemplate/Ts4UwpCsTemplate.fr-FR.vstemplate
@@ -9,7 +9,7 @@
 		<ProjectType>CSharp</ProjectType>
 		<LanguageTag>csharp</LanguageTag>
 		<SortOrder>10</SortOrder>
-		<TemplateID>61f19320-3820-4efd-a3e8-e1b1cca3352f</TemplateID>
+        <TemplateID>4EB69C1D-F03A-4842-9466-7A33EBB84528</TemplateID>
 		<CreateNewFolder>true</CreateNewFolder>
 		<DefaultName>App</DefaultName>
 		<ProvideDefaultName>true</ProvideDefaultName>

--- a/code/src/ProjectTemplates/UWP/CS/Ts4UwpCsTemplate/Ts4UwpCsTemplate.it-IT.vstemplate
+++ b/code/src/ProjectTemplates/UWP/CS/Ts4UwpCsTemplate/Ts4UwpCsTemplate.it-IT.vstemplate
@@ -9,7 +9,7 @@
 		<ProjectType>CSharp</ProjectType>
 		<LanguageTag>csharp</LanguageTag>
 		<SortOrder>10</SortOrder>
-		<TemplateID>61f19320-3820-4efd-a3e8-e1b1cca3352f</TemplateID>
+        <TemplateID>4EB69C1D-F03A-4842-9466-7A33EBB84528</TemplateID>
 		<CreateNewFolder>true</CreateNewFolder>
 		<DefaultName>App</DefaultName>
 		<ProvideDefaultName>true</ProvideDefaultName>

--- a/code/src/ProjectTemplates/UWP/CS/Ts4UwpCsTemplate/Ts4UwpCsTemplate.ja-JP.vstemplate
+++ b/code/src/ProjectTemplates/UWP/CS/Ts4UwpCsTemplate/Ts4UwpCsTemplate.ja-JP.vstemplate
@@ -9,7 +9,7 @@
 		<ProjectType>CSharp</ProjectType>
 		<LanguageTag>csharp</LanguageTag>
 		<SortOrder>10</SortOrder>
-		<TemplateID>61f19320-3820-4efd-a3e8-e1b1cca3352f</TemplateID>
+        <TemplateID>4EB69C1D-F03A-4842-9466-7A33EBB84528</TemplateID>
 		<CreateNewFolder>true</CreateNewFolder>
 		<DefaultName>App</DefaultName>
 		<ProvideDefaultName>true</ProvideDefaultName>

--- a/code/src/ProjectTemplates/UWP/CS/Ts4UwpCsTemplate/Ts4UwpCsTemplate.ko-KR.vstemplate
+++ b/code/src/ProjectTemplates/UWP/CS/Ts4UwpCsTemplate/Ts4UwpCsTemplate.ko-KR.vstemplate
@@ -9,7 +9,7 @@
 		<ProjectType>CSharp</ProjectType>
 		<LanguageTag>csharp</LanguageTag>
 		<SortOrder>10</SortOrder>
-		<TemplateID>61f19320-3820-4efd-a3e8-e1b1cca3352f</TemplateID>
+        <TemplateID>4EB69C1D-F03A-4842-9466-7A33EBB84528</TemplateID>
 		<CreateNewFolder>true</CreateNewFolder>
 		<DefaultName>App</DefaultName>
 		<ProvideDefaultName>true</ProvideDefaultName>

--- a/code/src/ProjectTemplates/UWP/CS/Ts4UwpCsTemplate/Ts4UwpCsTemplate.pl-PL.vstemplate
+++ b/code/src/ProjectTemplates/UWP/CS/Ts4UwpCsTemplate/Ts4UwpCsTemplate.pl-PL.vstemplate
@@ -9,7 +9,7 @@
 		<ProjectType>CSharp</ProjectType>
 		<LanguageTag>csharp</LanguageTag>
 		<SortOrder>10</SortOrder>
-		<TemplateID>61f19320-3820-4efd-a3e8-e1b1cca3352f</TemplateID>
+        <TemplateID>4EB69C1D-F03A-4842-9466-7A33EBB84528</TemplateID>
 		<CreateNewFolder>true</CreateNewFolder>
 		<DefaultName>App</DefaultName>
 		<ProvideDefaultName>true</ProvideDefaultName>

--- a/code/src/ProjectTemplates/UWP/CS/Ts4UwpCsTemplate/Ts4UwpCsTemplate.pt-BR.vstemplate
+++ b/code/src/ProjectTemplates/UWP/CS/Ts4UwpCsTemplate/Ts4UwpCsTemplate.pt-BR.vstemplate
@@ -9,7 +9,7 @@
 		<ProjectType>CSharp</ProjectType>
 		<LanguageTag>csharp</LanguageTag>
 		<SortOrder>10</SortOrder>
-		<TemplateID>61f19320-3820-4efd-a3e8-e1b1cca3352f</TemplateID>
+        <TemplateID>4EB69C1D-F03A-4842-9466-7A33EBB84528</TemplateID>
 		<CreateNewFolder>true</CreateNewFolder>
 		<DefaultName>App</DefaultName>
 		<ProvideDefaultName>true</ProvideDefaultName>

--- a/code/src/ProjectTemplates/UWP/CS/Ts4UwpCsTemplate/Ts4UwpCsTemplate.ru-RU.vstemplate
+++ b/code/src/ProjectTemplates/UWP/CS/Ts4UwpCsTemplate/Ts4UwpCsTemplate.ru-RU.vstemplate
@@ -9,7 +9,7 @@
 		<ProjectType>CSharp</ProjectType>
 		<LanguageTag>csharp</LanguageTag>
 		<SortOrder>10</SortOrder>
-		<TemplateID>61f19320-3820-4efd-a3e8-e1b1cca3352f</TemplateID>
+        <TemplateID>4EB69C1D-F03A-4842-9466-7A33EBB84528</TemplateID>
 		<CreateNewFolder>true</CreateNewFolder>
 		<DefaultName>App</DefaultName>
 		<ProvideDefaultName>true</ProvideDefaultName>

--- a/code/src/ProjectTemplates/UWP/CS/Ts4UwpCsTemplate/Ts4UwpCsTemplate.tr-TR.vstemplate
+++ b/code/src/ProjectTemplates/UWP/CS/Ts4UwpCsTemplate/Ts4UwpCsTemplate.tr-TR.vstemplate
@@ -9,7 +9,7 @@
 		<ProjectType>CSharp</ProjectType>
 		<LanguageTag>csharp</LanguageTag>
 		<SortOrder>10</SortOrder>
-		<TemplateID>61f19320-3820-4efd-a3e8-e1b1cca3352f</TemplateID>
+		<TemplateID>4EB69C1D-F03A-4842-9466-7A33EBB84528</TemplateID>
 		<CreateNewFolder>true</CreateNewFolder>
 		<DefaultName>App</DefaultName>
 		<ProvideDefaultName>true</ProvideDefaultName>

--- a/code/src/ProjectTemplates/UWP/CS/Ts4UwpCsTemplate/Ts4UwpCsTemplate.vstemplate
+++ b/code/src/ProjectTemplates/UWP/CS/Ts4UwpCsTemplate/Ts4UwpCsTemplate.vstemplate
@@ -10,7 +10,7 @@
 		<ProjectType>CSharp</ProjectType>
 		<LanguageTag>csharp</LanguageTag>
 		<SortOrder>10</SortOrder>
-		<TemplateID>61f19320-3820-4efd-a3e8-e1b1cca3352f</TemplateID>
+		<TemplateID>4EB69C1D-F03A-4842-9466-7A33EBB84528</TemplateID>
 		<CreateNewFolder>true</CreateNewFolder>
 		<DefaultName>App</DefaultName>
 		<ProvideDefaultName>true</ProvideDefaultName>

--- a/code/src/ProjectTemplates/UWP/CS/Ts4UwpCsTemplate/Ts4UwpCsTemplate.zh-CN.vstemplate
+++ b/code/src/ProjectTemplates/UWP/CS/Ts4UwpCsTemplate/Ts4UwpCsTemplate.zh-CN.vstemplate
@@ -9,7 +9,7 @@
 		<ProjectType>CSharp</ProjectType>
 		<LanguageTag>csharp</LanguageTag>
 		<SortOrder>10</SortOrder>
-		<TemplateID>61f19320-3820-4efd-a3e8-e1b1cca3352f</TemplateID>
+        <TemplateID>4EB69C1D-F03A-4842-9466-7A33EBB84528</TemplateID>
 		<CreateNewFolder>true</CreateNewFolder>
 		<DefaultName>App</DefaultName>
 		<ProvideDefaultName>true</ProvideDefaultName>

--- a/code/src/ProjectTemplates/UWP/CS/Ts4UwpCsTemplate/Ts4UwpCsTemplate.zh-TW.vstemplate
+++ b/code/src/ProjectTemplates/UWP/CS/Ts4UwpCsTemplate/Ts4UwpCsTemplate.zh-TW.vstemplate
@@ -9,7 +9,7 @@
 		<ProjectType>CSharp</ProjectType>
 		<LanguageTag>csharp</LanguageTag>
 		<SortOrder>10</SortOrder>
-		<TemplateID>61f19320-3820-4efd-a3e8-e1b1cca3352f</TemplateID>
+        <TemplateID>4EB69C1D-F03A-4842-9466-7A33EBB84528</TemplateID>
 		<CreateNewFolder>true</CreateNewFolder>
 		<DefaultName>App</DefaultName>
 		<ProvideDefaultName>true</ProvideDefaultName>


### PR DESCRIPTION
# PR checklist

**Quick summary of changes**

Don't use a GUID that's also used in a different extension

**Which issue does this PR relate to?**

Fixes #4511

**Applies to the following platforms:**

- [ ] WinUI
- [ ] WPF
- [x] UWP

**Anything that requires particular review or attention?**

Nope. THis is just me fixing a cut&paste error from the initial VS2022 support work

**Do all automated tests pass?**

yes

**Have automated tests been added for new features?**

n/a

**If you've changed the UI:**
  - Be sure you are including screenshots to show the changes.
  - Be sure you have reviewed the [accessibility checklist](accessibility.md).

n/a

**If you've included a new template:**
  - Be sure you reviewed the [Template Verification Checklist](https://github.com/microsoft/TemplateStudio/wiki/Checklist:-Template-Verification).
  - Be sure it's included in the list on this [UWP](https://github.com/microsoft/TemplateStudio/blob/main/docs/UWP/getting-started-endusers.md) or [WPF](https://github.com/microsoft/TemplateStudio/blob/main/docs/WPF/getting-started-endusers.md) getting started doc.

n/a

**Have you raised issues for any needed follow-on work?**

n/a

**Have docs been updated?**

n/a

**If breaking changes or different ways of doing things have been introduced, have they been communicated widely?**

n/a
