### PR TITLE
Workaround for TitleBar text not updating correctly

### DIFF
--- a/code/TemplateStudioForWinUICs/Templates/Proj/Default/Param_ProjectName/Helpers/TitleBarHelper.cs
+++ b/code/TemplateStudioForWinUICs/Templates/Proj/Default/Param_ProjectName/Helpers/TitleBarHelper.cs
@@ -29,7 +29,7 @@ internal class TitleBarHelper
             {
                 theme = Application.Current.RequestedTheme == ApplicationTheme.Light ? ElementTheme.Light : ElementTheme.Dark;
             }
-                
+
             Application.Current.Resources["WindowCaptionForeground"] = theme switch
             {
                 ElementTheme.Dark => new SolidColorBrush(Colors.White),

--- a/code/TemplateStudioForWinUICs/Templates/Proj/Default/Param_ProjectName/Helpers/TitleBarHelper.cs
+++ b/code/TemplateStudioForWinUICs/Templates/Proj/Default/Param_ProjectName/Helpers/TitleBarHelper.cs
@@ -26,7 +26,9 @@ internal class TitleBarHelper
         if (App.MainWindow.ExtendsContentIntoTitleBar)
         {
             if (theme == ElementTheme.Default)
+            {
                 theme = Application.Current.RequestedTheme == ApplicationTheme.Light? ElementTheme.Light : ElementTheme.Dark;
+            }
                 
             Application.Current.Resources["WindowCaptionForeground"] = theme switch
             {

--- a/code/TemplateStudioForWinUICs/Templates/Proj/Default/Param_ProjectName/Helpers/TitleBarHelper.cs
+++ b/code/TemplateStudioForWinUICs/Templates/Proj/Default/Param_ProjectName/Helpers/TitleBarHelper.cs
@@ -27,7 +27,7 @@ internal class TitleBarHelper
         {
             if (theme == ElementTheme.Default)
             {
-                theme = Application.Current.RequestedTheme == ApplicationTheme.Light? ElementTheme.Light : ElementTheme.Dark;
+                theme = Application.Current.RequestedTheme == ApplicationTheme.Light ? ElementTheme.Light : ElementTheme.Dark;
             }
                 
             Application.Current.Resources["WindowCaptionForeground"] = theme switch

--- a/code/TemplateStudioForWinUICs/Templates/Proj/Default/Param_ProjectName/Helpers/TitleBarHelper.cs
+++ b/code/TemplateStudioForWinUICs/Templates/Proj/Default/Param_ProjectName/Helpers/TitleBarHelper.cs
@@ -25,50 +25,50 @@ internal class TitleBarHelper
     {
         if (App.MainWindow.ExtendsContentIntoTitleBar)
         {
-            if (theme != ElementTheme.Default)
+            if (theme == ElementTheme.Default)
+                theme = Application.Current.RequestedTheme == ApplicationTheme.Light? ElementTheme.Light : ElementTheme.Dark;
+                
+            Application.Current.Resources["WindowCaptionForeground"] = theme switch
             {
-                Application.Current.Resources["WindowCaptionForeground"] = theme switch
-                {
-                    ElementTheme.Dark => new SolidColorBrush(Colors.White),
-                    ElementTheme.Light => new SolidColorBrush(Colors.Black),
-                    _ => new SolidColorBrush(Colors.Transparent)
-                };
+                ElementTheme.Dark => new SolidColorBrush(Colors.White),
+                ElementTheme.Light => new SolidColorBrush(Colors.Black),
+                _ => new SolidColorBrush(Colors.Transparent)
+            };
 
-                Application.Current.Resources["WindowCaptionForegroundDisabled"] = theme switch
-                {
-                    ElementTheme.Dark => new SolidColorBrush(Color.FromArgb(0x66, 0xFF, 0xFF, 0xFF)),
-                    ElementTheme.Light => new SolidColorBrush(Color.FromArgb(0x66, 0x00, 0x00, 0x00)),
-                    _ => new SolidColorBrush(Colors.Transparent)
-                };
+            Application.Current.Resources["WindowCaptionForegroundDisabled"] = theme switch
+            {
+                ElementTheme.Dark => new SolidColorBrush(Color.FromArgb(0x66, 0xFF, 0xFF, 0xFF)),
+                ElementTheme.Light => new SolidColorBrush(Color.FromArgb(0x66, 0x00, 0x00, 0x00)),
+                _ => new SolidColorBrush(Colors.Transparent)
+            };
 
-                Application.Current.Resources["WindowCaptionButtonBackgroundPointerOver"] = theme switch
-                {
-                    ElementTheme.Dark => new SolidColorBrush(Color.FromArgb(0x33, 0xFF, 0xFF, 0xFF)),
-                    ElementTheme.Light => new SolidColorBrush(Color.FromArgb(0x33, 0x00, 0x00, 0x00)),
-                    _ => new SolidColorBrush(Colors.Transparent)
-                };
+            Application.Current.Resources["WindowCaptionButtonBackgroundPointerOver"] = theme switch
+            {
+                ElementTheme.Dark => new SolidColorBrush(Color.FromArgb(0x33, 0xFF, 0xFF, 0xFF)),
+                ElementTheme.Light => new SolidColorBrush(Color.FromArgb(0x33, 0x00, 0x00, 0x00)),
+                _ => new SolidColorBrush(Colors.Transparent)
+            };
 
-                Application.Current.Resources["WindowCaptionButtonBackgroundPressed"] = theme switch
-                {
-                    ElementTheme.Dark => new SolidColorBrush(Color.FromArgb(0x66, 0xFF, 0xFF, 0xFF)),
-                    ElementTheme.Light => new SolidColorBrush(Color.FromArgb(0x66, 0x00, 0x00, 0x00)),
-                    _ => new SolidColorBrush(Colors.Transparent)
-                };
+            Application.Current.Resources["WindowCaptionButtonBackgroundPressed"] = theme switch
+            {
+                ElementTheme.Dark => new SolidColorBrush(Color.FromArgb(0x66, 0xFF, 0xFF, 0xFF)),
+                ElementTheme.Light => new SolidColorBrush(Color.FromArgb(0x66, 0x00, 0x00, 0x00)),
+                _ => new SolidColorBrush(Colors.Transparent)
+            };
 
-                Application.Current.Resources["WindowCaptionButtonStrokePointerOver"] = theme switch
-                {
-                    ElementTheme.Dark => new SolidColorBrush(Colors.White),
-                    ElementTheme.Light => new SolidColorBrush(Colors.Black),
-                    _ => new SolidColorBrush(Colors.Transparent)
-                };
+            Application.Current.Resources["WindowCaptionButtonStrokePointerOver"] = theme switch
+            {
+                ElementTheme.Dark => new SolidColorBrush(Colors.White),
+                ElementTheme.Light => new SolidColorBrush(Colors.Black),
+                _ => new SolidColorBrush(Colors.Transparent)
+            };
 
-                Application.Current.Resources["WindowCaptionButtonStrokePressed"] = theme switch
-                {
-                    ElementTheme.Dark => new SolidColorBrush(Colors.White),
-                    ElementTheme.Light => new SolidColorBrush(Colors.Black),
-                    _ => new SolidColorBrush(Colors.Transparent)
-                };
-            }
+            Application.Current.Resources["WindowCaptionButtonStrokePressed"] = theme switch
+            {
+                ElementTheme.Dark => new SolidColorBrush(Colors.White),
+                ElementTheme.Light => new SolidColorBrush(Colors.Black),
+                _ => new SolidColorBrush(Colors.Transparent)
+            };
 
             Application.Current.Resources["WindowCaptionBackground"] = new SolidColorBrush(Colors.Transparent);
             Application.Current.Resources["WindowCaptionBackgroundDisabled"] = new SolidColorBrush(Colors.Transparent);


### PR DESCRIPTION
# PR checklist

**Quick summary of changes**
Workaround for TitleBarHelper not updating correctly.
If `theme` param is default, it checks `Application.Current.RequestedTheme`, which returns the value of the default system theme, and it only has two posible values (dark and light).
With a boolean logic to check the actual system theme, it overrides the theme for the TitleBar.

Also deleted `if (theme != ElementTheme.Default)` because is redundant and aligned correctly the code that was inside the conditional clause.

**Which issue does this PR relate to?**
#4599
**Applies to the following platforms:**

- [x] WinUI
- [ ] WPF
- [ ] UWP

**Anything that requires particular review or attention?**

**Do all automated tests pass?**
Didn't tested
**Have automated tests been added for new features?**
No
**If you've changed the UI:**
  - Be sure you are including screenshots to show the changes.
  - Be sure you have reviewed the [accessibility checklist](accessibility.md).

**If you've included a new template:**
  - Be sure you reviewed the [Template Verification Checklist](https://github.com/microsoft/TemplateStudio/wiki/Checklist:-Template-Verification).
  - Be sure it's included in the list on this [UWP](https://github.com/microsoft/TemplateStudio/blob/main/docs/UWP/getting-started-endusers.md) or [WPF](https://github.com/microsoft/TemplateStudio/blob/main/docs/WPF/getting-started-endusers.md) getting started doc.

**Have you raised issues for any needed follow-on work?**
No
**Have docs been updated?**
No
**If breaking changes or different ways of doing things have been introduced, have they been communicated widely?**
No breaking changes.