### PR TITLE
Update to latest WinAppSDK version 1.2.3

### DIFF
--- a/code/TemplateStudioForWinUICpp/Templates/Projects/Default/.template.config/template.json
+++ b/code/TemplateStudioForWinUICpp/Templates/Projects/Default/.template.config/template.json
@@ -20,7 +20,7 @@
     "ts.outputToParent": "true",
     "ts.version": "1.0.0",
     "ts.displayOrder": "0",
-    "ts.licenses": "[Microsoft.WindowsAppSDK](https://www.nuget.org/packages/Microsoft.WindowsAppSDK/1.0.1/License)|[Microsoft.Windows.CppWinRT](https://www.nuget.org/packages/Microsoft.Windows.CppWinRT/2.0.220331.4/License)"
+    "ts.licenses": "[Microsoft.WindowsAppSDK](https://www.nuget.org/packages/Microsoft.WindowsAppSDK/1.2.230118.102/License)|[Microsoft.Windows.CppWinRT](https://www.nuget.org/packages/Microsoft.Windows.CppWinRT/2.0.220331.4/License)"
   },
   "sourceName": "Param_ProjectName",
   "preferNameDirectory": true,
@@ -91,7 +91,7 @@
       "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
       "args": {
         "packageId": "Microsoft.WindowsAppSDK",
-        "version": "1.0.1",
+        "version": "1.2.230118.102",
         "projectPath": "Param_ProjectName\\Param_ProjectName.vcxproj"
       },
       "continueOnError": true

--- a/code/TemplateStudioForWinUICs/Templates/Proj/Default/.template.config/template.json
+++ b/code/TemplateStudioForWinUICs/Templates/Proj/Default/.template.config/template.json
@@ -20,7 +20,7 @@
         "ts.outputToParent": "true",
         "ts.version": "1.0.0",
         "ts.displayOrder": "0",
-        "ts.licenses": "[Microsoft.WindowsAppSDK](https://www.nuget.org/packages/Microsoft.WindowsAppSDK/1.2.221209.1/License)|[WinUIEx](https://licenses.nuget.org/Apache-2.0)"
+        "ts.licenses": "[Microsoft.WindowsAppSDK](https://www.nuget.org/packages/Microsoft.WindowsAppSDK/1.2.230118.102/License)|[WinUIEx](https://licenses.nuget.org/Apache-2.0)"
     },
     "sourceName": "Param_ProjectName",
     "preferNameDirectory": true,
@@ -87,7 +87,7 @@
             "actionId": "0B814718-16A3-4F7F-89F1-69C0F9170EAD",
             "args": {
                 "packageId": "Microsoft.WindowsAppSDK",
-                "version": "1.2.221209.1",
+                "version": "1.2.230118.102",
                 "projectPath": "Param_ProjectName\\Param_ProjectName.csproj"
             },
             "continueOnError": true


### PR DESCRIPTION
I have updated nuget references to winappsdk to point to the latest version which is 1.2.3
https://www.nuget.org/packages/Microsoft.WindowsAppSDK
I have tested it locally and created projects do reference 1.2.3

**Applies to the following platforms:**

- [X] WinUI
- [ ] WPF
- [ ] UWP
