### PR TITLE
Remove designer references from WinUI templates.

### DIFF
--- a/code/TemplateStudioForWinUICs/Templates/Pg/Blank/Views/Param_ItemNamePage.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/Pg/Blank/Views/Param_ItemNamePage.xaml
@@ -1,10 +1,7 @@
 ﻿<Page
     x:Class="Param_RootNamespace.Views.Param_ItemNamePage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d">
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
     <Grid x:Name="ContentArea">
         

--- a/code/TemplateStudioForWinUICs/Templates/Pg/CGrid/Param_ProjectName/Views/Param_ItemNameDetailPage.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/Pg/CGrid/Param_ProjectName/Views/Param_ItemNameDetailPage.xaml
@@ -2,11 +2,8 @@
     x:Class="Param_RootNamespace.Views.Param_ItemNameDetailPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:CommunityToolkit.WinUI.UI.Controls"
-    xmlns:models="using:Param_RootNamespace.Core.Models"
-    mc:Ignorable="d">
+    xmlns:models="using:Param_RootNamespace.Core.Models">
 
     <Grid x:Name="ContentArea">
 

--- a/code/TemplateStudioForWinUICs/Templates/Pg/CGrid/Param_ProjectName/Views/Param_ItemNamePage.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/Pg/CGrid/Param_ProjectName/Views/Param_ItemNamePage.xaml
@@ -2,12 +2,9 @@
     x:Class="Param_RootNamespace.Views.Param_ItemNamePage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:animations="using:CommunityToolkit.WinUI.UI.Animations"
     xmlns:controls="using:CommunityToolkit.WinUI.UI.Controls"
-    xmlns:models="using:Param_RootNamespace.Core.Models"
-    mc:Ignorable="d">
+    xmlns:models="using:Param_RootNamespace.Core.Models">
 
     <Grid x:Name="ContentArea">
         <controls:AdaptiveGridView

--- a/code/TemplateStudioForWinUICs/Templates/Pg/DGrid/Param_ProjectName/Views/Param_ItemNamePage.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/Pg/DGrid/Param_ProjectName/Views/Param_ItemNamePage.xaml
@@ -2,10 +2,7 @@
     x:Class="Param_RootNamespace.Views.Param_ItemNamePage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:controls="using:CommunityToolkit.WinUI.UI.Controls"
-    mc:Ignorable="d">
+    xmlns:controls="using:CommunityToolkit.WinUI.UI.Controls">
 
     <Grid x:Name="ContentArea">
         <controls:DataGrid

--- a/code/TemplateStudioForWinUICs/Templates/Pg/Form/Param_ProjectName/Views/Param_ItemNamePage.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/Pg/Form/Param_ProjectName/Views/Param_ItemNamePage.xaml
@@ -2,10 +2,7 @@
     x:Class="Param_RootNamespace.Views.Param_ItemNamePage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:models="using:Param_RootNamespace.Core.Models"
-    mc:Ignorable="d">
+    xmlns:models="using:Param_RootNamespace.Core.Models">
 
     <ScrollViewer>
         <VisualStateManager.VisualStateGroups>

--- a/code/TemplateStudioForWinUICs/Templates/Pg/List/Param_ProjectName/Views/Param_ItemNameDetailControl.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/Pg/List/Param_ProjectName/Views/Param_ItemNameDetailControl.xaml
@@ -1,10 +1,7 @@
 ﻿<UserControl
     x:Class="Param_RootNamespace.Views.Param_ItemNameDetailControl"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d">
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <ScrollViewer
         Name="ForegroundElement"
         HorizontalAlignment="Stretch"

--- a/code/TemplateStudioForWinUICs/Templates/Pg/List/Param_ProjectName/Views/Param_ItemNamePage.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/Pg/List/Param_ProjectName/Views/Param_ItemNamePage.xaml
@@ -2,12 +2,9 @@
     x:Class="Param_RootNamespace.Views.Param_ItemNamePage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:CommunityToolkit.WinUI.UI.Controls"
     xmlns:models="using:Param_RootNamespace.Core.Models"
-    xmlns:views="using:Param_RootNamespace.Views"
-    mc:Ignorable="d">
+    xmlns:views="using:Param_RootNamespace.Views">
     <Page.Resources>
         <DataTemplate x:Key="ItemTemplate" x:DataType="models:SampleOrder">
             <Grid Height="60">

--- a/code/TemplateStudioForWinUICs/Templates/Pg/Settings/Views/Param_ItemNamePage.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/Pg/Settings/Views/Param_ItemNamePage.xaml
@@ -2,11 +2,8 @@
     x:Class="Param_RootNamespace.Views.Param_ItemNamePage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:helpers="using:Param_RootNamespace.Helpers"
-    xmlns:xaml="using:Microsoft.UI.Xaml"
-    mc:Ignorable="d">
+    xmlns:xaml="using:Microsoft.UI.Xaml">
     <Page.Resources>
         <helpers:EnumToBooleanConverter x:Key="EnumToBooleanConverter" />
     </Page.Resources>

--- a/code/TemplateStudioForWinUICs/Templates/Pg/WebView/Views/Param_ItemNamePage.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/Pg/WebView/Views/Param_ItemNamePage.xaml
@@ -1,10 +1,7 @@
 ﻿<Page
     x:Class="Param_RootNamespace.Views.Param_ItemNamePage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d">
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
     <Grid x:Name="ContentArea">
         <Grid.RowDefinitions>

--- a/code/TemplateStudioForWinUICs/Templates/Proj/Default/Param_ProjectName/MainWindow.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/Proj/Default/Param_ProjectName/MainWindow.xaml
@@ -3,13 +3,10 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Param_RootNamespace"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:windowex="using:WinUIEx"
     MinWidth="500"
     MinHeight="500"
-    PersistenceId="MainWindow"
-    mc:Ignorable="d">
+    PersistenceId="MainWindow">
     <windowex:WindowEx.Backdrop>
         <windowex:MicaSystemBackdrop/>
     </windowex:WindowEx.Backdrop>

--- a/code/TemplateStudioForWinUICs/Templates/_comp/MT/Page.AddBackCommand/Views/Param_ItemNameDetailPage_postaction.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/_comp/MT/Page.AddBackCommand/Views/Param_ItemNameDetailPage_postaction.xaml
@@ -1,5 +1,4 @@
-﻿<Page
-    mc:Ignorable="d">
+﻿<Page>
 
     <Grid x:Name="ContentArea">
 <!--{[{-->

--- a/code/TemplateStudioForWinUICs/Templates/_comp/MT/Project.MenuBar/Views/ShellPage.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/_comp/MT/Project.MenuBar/Views/ShellPage.xaml
@@ -2,12 +2,9 @@
     x:Class="Param_RootNamespace.Views.ShellPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:animatedvisuals="using:Microsoft.UI.Xaml.Controls.AnimatedVisuals"
     Loaded="OnLoaded"
-    Unloaded="OnUnloaded"
-    mc:Ignorable="d">
+    Unloaded="OnUnloaded">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="32" />

--- a/code/TemplateStudioForWinUICs/Templates/_comp/MT/Project.NavView/Views/ShellPage.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/_comp/MT/Project.NavView/Views/ShellPage.xaml
@@ -2,8 +2,6 @@
     x:Class="Param_RootNamespace.Views.ShellPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:helpers="using:Param_RootNamespace.Helpers"
     xmlns:behaviors="using:Param_RootNamespace.Behaviors"
     xmlns:i="using:Microsoft.Xaml.Interactivity"

--- a/code/TemplateStudioForWinUICs/Templates/_comp/_shared/Page.AddBackground.Blank/Views/Param_ItemNamePage_postaction.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/_comp/_shared/Page.AddBackground.Blank/Views/Param_ItemNamePage_postaction.xaml
@@ -2,5 +2,4 @@
     <!--^^-->
     <!--{[{-->
     Background="{ThemeResource SolidBackgroundFillColorBaseBrush}"
-    <!--}]}-->
-    mc:Ignorable="d">
+    <!--}]}-->>

--- a/code/TemplateStudioForWinUICs/Templates/_comp/_shared/Page.AddTitle.Blank/Views/Param_ItemNamePage_postaction.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/_comp/_shared/Page.AddTitle.Blank/Views/Param_ItemNamePage_postaction.xaml
@@ -1,5 +1,4 @@
-﻿<Page
-    mc:Ignorable="d">
+﻿<Page>
 
     <Grid x:Name="ContentArea">
 <!--{[{-->

--- a/code/TemplateStudioForWinUICs/Templates/_comp/_shared/Page.AddTitle.ContentGrid/Views/Param_ItemNamePage_postaction.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/_comp/_shared/Page.AddTitle.ContentGrid/Views/Param_ItemNamePage_postaction.xaml
@@ -1,5 +1,4 @@
-﻿<Page
-    mc:Ignorable="d">
+﻿<Page>
 
     <Grid x:Name="ContentArea">
 <!--{[{-->

--- a/code/TemplateStudioForWinUICs/Templates/_comp/_shared/Page.AddTitle.DataGrid/Views/Param_ItemNamePage_postaction.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/_comp/_shared/Page.AddTitle.DataGrid/Views/Param_ItemNamePage_postaction.xaml
@@ -1,5 +1,4 @@
-﻿<Page
-    mc:Ignorable="d">
+﻿<Page>
 
     <Grid x:Name="ContentArea">
 <!--{[{-->

--- a/code/TemplateStudioForWinUICs/Templates/_comp/_shared/Page.AddTitle.Form/Views/Param_ItemNamePage_postaction.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/_comp/_shared/Page.AddTitle.Form/Views/Param_ItemNamePage_postaction.xaml
@@ -1,5 +1,4 @@
-﻿<Page
-    mc:Ignorable="d">
+﻿<Page>
     
     <ScrollViewer>
         <StackPanel

--- a/code/TemplateStudioForWinUICs/Templates/_comp/_shared/Page.AddTitle.Settings/Views/Param_ItemNamePage_postaction.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/_comp/_shared/Page.AddTitle.Settings/Views/Param_ItemNamePage_postaction.xaml
@@ -1,5 +1,4 @@
-﻿<Page
-    mc:Ignorable="d">
+﻿<Page>
     <Grid>
 <!--{[{-->
         <Grid.RowDefinitions>

--- a/code/TemplateStudioForWinUICs/Templates/_comp/_shared/Page.ListDetail.Blank.MenuBar/Views/Param_ItemNamePage_postaction.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/_comp/_shared/Page.ListDetail.Blank.MenuBar/Views/Param_ItemNamePage_postaction.xaml
@@ -1,5 +1,4 @@
-﻿<Page
-    mc:Ignorable="d">
+﻿<Page>
 
     <Grid x:Name="ContentArea">
         <controls:ListDetailsView

--- a/code/TemplateStudioForWinUICs/Templates/_comp/_shared/Page.ListDetail.NavView/Views/Param_ItemNamePage_postaction.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/_comp/_shared/Page.ListDetail.NavView/Views/Param_ItemNamePage_postaction.xaml
@@ -3,8 +3,7 @@
     <!--{[{-->
     xmlns:behaviors="using:Param_RootNamespace.Behaviors"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
-    <!--}]}-->
-    mc:Ignorable="d">
+    <!--}]}-->>
 
     <Page.Resources>
         <!--^^-->

--- a/code/TemplateStudioForWinUICs/Templates/_comp/_shared/Page.NavView.AddHeaderModeNever/Views/Param_ItemNamePage_postaction.xaml
+++ b/code/TemplateStudioForWinUICs/Templates/_comp/_shared/Page.NavView.AddHeaderModeNever/Views/Param_ItemNamePage_postaction.xaml
@@ -3,6 +3,5 @@
     <!--{[{-->
     xmlns:behaviors="using:Param_RootNamespace.Behaviors"
     behaviors:NavigationViewHeaderBehavior.HeaderMode="Never"
-    <!--}]}-->
-    mc:Ignorable="d">
+    <!--}]}-->>
 </Page>


### PR DESCRIPTION
# PR checklist

**Quick summary of changes**

This PR removes all designer references from the WinUI 3 / WASDK templates.

**Which issue does this PR relate to?**

#4646

**Applies to the following platforms:**

- [X] WinUI
- [ ] WPF
- [ ] UWP

**Anything that requires particular review or attention?**

Any objections?

**Do all automated tests pass?**

Unknown

**Have docs been updated?**

Unsure if the docs ever show sample WinUI 3 / WASDK templates with designer references.
