### PR TITLE
Use Dictionary.ContainsValue to replace Linq.Any

### DIFF
--- a/code/TemplateStudioForWPF/Templates/_comp/MT/Project/Services/PageService.cs
+++ b/code/TemplateStudioForWPF/Templates/_comp/MT/Project/Services/PageService.cs
@@ -49,7 +49,7 @@ public class PageService : IPageService
             }
 
             var type = typeof(V);
-            if (_pages.Any(p => p.Value == type))
+            if (_pages.ContainsValue(type))
             {
                 throw new ArgumentException($"This type is already configured with key {_pages.First(p => p.Value == type).Key}");
             }

--- a/code/TemplateStudioForWinUICs/Templates/_comp/MT/Project/Services/PageService.cs
+++ b/code/TemplateStudioForWinUICs/Templates/_comp/MT/Project/Services/PageService.cs
@@ -41,7 +41,7 @@ public class PageService : IPageService
             }
 
             var type = typeof(V);
-            if (_pages.Any(p => p.Value == type))
+            if (_pages.ContainsValue(type))
             {
                 throw new ArgumentException($"This type is already configured with key {_pages.First(p => p.Value == type).Key}");
             }


### PR DESCRIPTION
# PR checklist

**Quick summary of changes**

In `PageService`, use `_pages.ContainsValue(type)` to replace `_pages.Any(p => p.Value == type)`

**Which issue does this PR relate to?**

**Applies to the following platforms:**

- [x] WinUI
- [x] WPF
- [ ] UWP
