### PR TITLE
Adds support for app execution alias

### DIFF
--- a/code/TemplateStudioForWinUICs/Templates/Ft/MSIX/Package.appxmanifest
+++ b/code/TemplateStudioForWinUICs/Templates/Ft/MSIX/Package.appxmanifest
@@ -4,11 +4,12 @@
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
   xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
   xmlns:genTemplate="http://schemas.microsoft.com/appx/developer/templatestudio"
   xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10"
   xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10"
-  IgnorableNamespaces="uap rescap genTemplate">
+  IgnorableNamespaces="uap uap5 rescap genTemplate">
 
   <Identity
     Name="07ad151b-a614-4a13-aef0-5378d3f98e67"
@@ -57,6 +58,13 @@
                   </com:ExeServer>
               </com:ComServer>
           </com:Extension>
+
+        <uap5:Extension Category="windows.appExecutionAlias">
+          <uap5:AppExecutionAlias>
+            <uap5:ExecutionAlias Alias="Param_ProjectName.exe"/>
+          </uap5:AppExecutionAlias>
+        </uap5:Extension>
+
       </Extensions>
     </Application>
   </Applications>


### PR DESCRIPTION
# PR checklist

**Quick summary of changes**
This PR adds support for invoking the app from the command line using the app execution alias by defining it in the appxmanifest file

**Which issue does this PR relate to?**
#4695

**Applies to the following platforms:**

- [x] WinUI
- [ ] WPF
- [ ] UWP

**Anything that requires particular review or attention?**
No

**Do all automated tests pass?**
N/A

**Have automated tests been added for new features?**
N/A

**If you've changed the UI:**
  - Be sure you are including screenshots to show the changes.
  - Be sure you have reviewed the [accessibility checklist](accessibility.md).
N/A

**If you've included a new template:**
  - Be sure you reviewed the [Template Verification Checklist](https://github.com/microsoft/TemplateStudio/wiki/Checklist:-Template-Verification).
  - Be sure it's included in the list on this [UWP](https://github.com/microsoft/TemplateStudio/blob/main/docs/UWP/getting-started-endusers.md) or [WPF](https://github.com/microsoft/TemplateStudio/blob/main/docs/WPF/getting-started-endusers.md) getting started doc.
N/A

**Have you raised issues for any needed follow-on work?**
N/A

**Have docs been updated?**
N/A

**If breaking changes or different ways of doing things have been introduced, have they been communicated widely?**
N/A
