### PR TITLE
[WIP] change RuntimeIdentifier to win-xxx for .NET 8.0 -- fix issue #4717

### DIFF
--- a/code/TemplateStudioForWinUICs/Templates/Proj/Default/Param_ProjectName/Param_ProjectName.csproj
+++ b/code/TemplateStudioForWinUICs/Templates/Proj/Default/Param_ProjectName/Param_ProjectName.csproj
@@ -7,8 +7,8 @@
     <ApplicationIcon>Assets/WindowIcon.ico</ApplicationIcon>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;arm64</Platforms>
-    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
-    <PublishProfile>Properties\PublishProfiles\win10-$(Platform).pubxml</PublishProfile>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <PublishProfile>Properties\PublishProfiles\win-$(Platform).pubxml</PublishProfile>
 	<ImplicitUsings>enable</ImplicitUsings>
 	<Nullable>enable</Nullable>
 	<UseWinUI>true</UseWinUI>

--- a/code/TemplateStudioForWinUICs/Templates/Proj/Default/Param_ProjectName/Properties/PublishProfiles/win10-x86.pubxml
+++ b/code/TemplateStudioForWinUICs/Templates/Proj/Default/Param_ProjectName/Properties/PublishProfiles/win10-x86.pubxml
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x86</Platform>
-    <RuntimeIdentifier>win10-x86</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>True</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>


### PR DESCRIPTION
# PR checklist

**Quick summary of changes**
Fix .NET 8.0 `specified RuntimeIdentifier 'win10-x64' is not recognized. ` 

**Full Error** 
```
NETSDK1083	The specified RuntimeIdentifier 'win10-x64' is not recognized. See https://aka.ms/netsdk1083 for more information.
```

More info: https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/8.0/runtimeidentifier

###  Steps to Repeat
1. Create new project from template
2. Build Project

### Which issue does this PR relate to?
#4717 

### Applies to the following platforms

- [✅ ] WinUI
- [ ] WPF
- [ ] UWP

###  Anything that requires particular review or attention?
* I could use help on how to perform e2e test with Template Studio using the updated template from this branch.
* how to test this with earlier versions of .net e.g. .net 7 , .net 6
* how to run automation on my own. 



### Do all automated tests pass?
✅ yes

**Have automated tests been added for new features?**
N/A

**If you've changed the UI:**
n/a 

**If you've included a new template:**
n/a 

**Have you raised issues for any needed follow-on work?**
n/a

**Have docs been updated?**
no

**If breaking changes or different ways of doing things have been introduced, have they been communicated widely?**
