### PR TITLE
Fix a typo: indows->windows in comment

### DIFF
--- a/code/TemplateStudioForWinUICs/Templates/Proj/Default/Param_ProjectName/MainWindow.xaml.cs
+++ b/code/TemplateStudioForWinUICs/Templates/Proj/Default/Param_ProjectName/MainWindow.xaml.cs
@@ -22,7 +22,7 @@ public sealed partial class MainWindow : WindowEx
         settings.ColorValuesChanged += Settings_ColorValuesChanged; // cannot use FrameworkElement.ActualThemeChanged event
     }
 
-    // this handles updating the caption button colors correctly when indows system theme is changed
+    // this handles updating the caption button colors correctly when windows system theme is changed
     // while the app is open
     private void Settings_ColorValuesChanged(UISettings sender, object args)
     {


### PR DESCRIPTION
Fix a typo in `code/TemplateStudioForWinUICs/Templates/Proj/Default/Param_ProjectName/MainWindow.xaml.cs` line 25 comment `indows`, changed it to `windows`